### PR TITLE
Added application GUID as parameter to step

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -6,7 +6,7 @@ echo "build path "${build_path}""
 curl --location --request POST 'https://public.sofy.ai/parser-microservice/build-upload' \
 --header "x-sofy-auth-key: ${subscription_key}" \
 --form "applicationFile=@"${build_path}"" \
---form 'ApplicationGUID="${application_guid}""
+--form "ApplicationGUID="${application_guid}""
 #
 # --- Export Environment Variables for other Steps:
 # You can export Environment Variables for other Steps with

--- a/step.sh
+++ b/step.sh
@@ -3,8 +3,8 @@ set -ex
 
 #echo "This is the value specified for the input 'example_step_input': ${example_step_input}"
 echo "build path "${build_path}""
-curl --location --request POST 'https://api.sofy.ai/api/AppTests/buildUpload' \
---header "SubscriptionKey: ${subscription_key}" \
+curl --location --request POST 'https://public.sofy.ai/parser-microservice/build-upload' \
+--header "x-sofy-auth-key: ${subscription_key}" \
 --form "applicationFile=@"${build_path}"" \
 --form "ApplicationGuid="${application_guid}""
 #

--- a/step.sh
+++ b/step.sh
@@ -6,7 +6,7 @@ echo "build path "${build_path}""
 curl --location --request POST 'https://public.sofy.ai/parser-microservice/build-upload' \
 --header "x-sofy-auth-key: ${subscription_key}" \
 --form "applicationFile=@"${build_path}"" \
---form "ApplicationGuid="${application_guid}""
+--form 'ApplicationGUID="${application_guid}""
 #
 # --- Export Environment Variables for other Steps:
 # You can export Environment Variables for other Steps with

--- a/step.sh
+++ b/step.sh
@@ -5,7 +5,8 @@ set -ex
 echo "build path "${build_path}""
 curl --location --request POST 'https://api.sofy.ai/api/AppTests/buildUpload' \
 --header "SubscriptionKey: ${subscription_key}" \
---form "applicationFile=@"${build_path}""
+--form "applicationFile=@"${build_path}"" \
+--form "ApplicationGuid=="${application_guid}""
 #
 # --- Export Environment Variables for other Steps:
 # You can export Environment Variables for other Steps with

--- a/step.sh
+++ b/step.sh
@@ -6,7 +6,7 @@ echo "build path "${build_path}""
 curl --location --request POST 'https://api.sofy.ai/api/AppTests/buildUpload' \
 --header "SubscriptionKey: ${subscription_key}" \
 --form "applicationFile=@"${build_path}"" \
---form "ApplicationGuid=="${application_guid}""
+--form "ApplicationGuid="${application_guid}""
 #
 # --- Export Environment Variables for other Steps:
 # You can export Environment Variables for other Steps with

--- a/step.yml
+++ b/step.yml
@@ -73,6 +73,6 @@ inputs:
       title: Application GUID
       description: |
           Find your Sofy application guid by following the steps under [Finding and Copying an App's GUID](https://docs.sofy.ai/using-ap-is-for-testing/upload-apk-ipa-using-apis#finding_and_copying_an_app_s_guid)
-      isRequired: false
+      isRequired: true
       is_sensitive: true
 

--- a/step.yml
+++ b/step.yml
@@ -72,6 +72,7 @@ inputs:
     opts:
       title: Application GUID
       Description: |
-          Find your Sofy application guid by following the steps under [Finding and Copying an App's GUID](https://docs.sofy.ai/using-ap-is-for-testing/upload-apk-ipa-using-apis#finding_and_copying_an_app_s_guid)
+          Find your Sofy application guid by following the steps here https://docs.sofy.ai/using-ap-is-for-testing/upload-apk-ipa-using-apis#finding_and_copying_an_app_s_guid
       isRequired: false
+      is_sensitive: true
 

--- a/step.yml
+++ b/step.yml
@@ -68,3 +68,10 @@ inputs:
       is_required: true
       is_sensitive: true
 
+  - application_guid:
+    opts:
+      title: Application GUID
+      Description: |
+          Find your Sofy application guid by following the steps under [Finding and Copying an App's GUID](https://docs.sofy.ai/using-ap-is-for-testing/upload-apk-ipa-using-apis#finding_and_copying_an_app_s_guid)
+      isRequired: false
+

--- a/step.yml
+++ b/step.yml
@@ -71,8 +71,8 @@ inputs:
   - application_guid:
     opts:
       title: Application GUID
-      Description: |
-          Find your Sofy application guid by following the steps here https://docs.sofy.ai/using-ap-is-for-testing/upload-apk-ipa-using-apis#finding_and_copying_an_app_s_guid
+      description: |
+          Find your Sofy application guid by following the steps under [Finding and Copying an App's GUID](https://docs.sofy.ai/using-ap-is-for-testing/upload-apk-ipa-using-apis#finding_and_copying_an_app_s_guid)
       isRequired: false
       is_sensitive: true
 


### PR DESCRIPTION
The Bitrise Sofy upload step was updated to include the Sofy application GUID.

-  I chose to make the Application GUID required. From my point of view the GUID is required even though it can be optional. By not including it you can get some weird outcomes with Sofy just creating a new application. 
- You will want to update the `bitrise.yml -> workflows -> text -> inputs` to include the `application_guid `parameter as well. I am not sure what that GUID should be for the tests.  
